### PR TITLE
Toggle Headless UI components on button click 

### DIFF
--- a/packages/Tailwind/Ignis.Components.HeadlessUI/ListboxButton.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/ListboxButton.cs
@@ -118,6 +118,7 @@ public sealed class ListboxButton : IgnisComponentBase, IListboxButton
 
         if (@event.CancellationToken.IsCancellationRequested) return;
         
-        Listbox.Open();
+        if (Listbox.IsOpen) Listbox.Close();
+        else Listbox.Open();
     }
 }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/MenuButton.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/MenuButton.cs
@@ -115,7 +115,8 @@ public sealed class MenuButton : IgnisComponentBase, IMenuButton
         OnClick.InvokeAsync(@event);
 
         if (@event.CancellationToken.IsCancellationRequested) return;
-        
-        Menu.Open();
+
+        if (Menu.IsOpen) Menu.Close();
+        else Menu.Open();
     }
 }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/PopoverButton.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/PopoverButton.cs
@@ -109,6 +109,7 @@ public sealed class PopoverButton : IgnisComponentBase, IPopoverButton
 
         if (@event.CancellationToken.IsCancellationRequested) return;
         
-        Popover.Open();
+        if (Popover.IsOpen) Popover.Close();
+        else Popover.Open();
     }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -1,0 +1,46 @@
+﻿@inherits TestContext
+
+@code
+{
+    [Fact]
+    public void Button_OnClick()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = Render(@<Listbox TValue="object">
+                             <ListboxButton>
+                             </ListboxButton>
+                         </Listbox>);
+
+        cut.Find("button").Click();
+
+        var listbox = cut.FindComponent<Listbox<object>>();
+        Assert.True(listbox.Instance.IsOpen);
+
+        cut.Find("button").Click();
+
+        Assert.False(listbox.Instance.IsOpen);
+    }
+
+    [Fact]
+    public void Button_OnClick_PreventDefault()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = Render(@<Listbox TValue="object">
+                             <ListboxButton OnClick="e => e.PreventDefault()">
+                             </ListboxButton>
+                         </Listbox>);
+
+        cut.Find("button").Click();
+
+        var listbox = cut.FindComponent<Listbox<object>>();
+        Assert.False(listbox.Instance.IsOpen);
+    }
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/MenuTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/MenuTests.razor
@@ -1,0 +1,46 @@
+﻿@inherits TestContext
+
+@code
+{
+    [Fact]
+    public void Button_OnClick()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = Render(@<Menu>
+                             <MenuButton>
+                             </MenuButton>
+                         </Menu>);
+
+        cut.Find("button").Click();
+
+        var menu = cut.FindComponent<Menu>();
+        Assert.True(menu.Instance.IsOpen);
+
+        cut.Find("button").Click();
+
+        Assert.False(menu.Instance.IsOpen);
+    }
+
+    [Fact]
+    public void Button_OnClick_PreventDefault()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = Render(@<Menu>
+                             <MenuButton OnClick="e => e.PreventDefault()">
+                             </MenuButton>
+                         </Menu>);
+
+        cut.Find("button").Click();
+
+        var menu = cut.FindComponent<Menu>();
+        Assert.False(menu.Instance.IsOpen);
+    }
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/PopoverTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/PopoverTests.razor
@@ -19,6 +19,10 @@
 
         var popover = cut.FindComponent<Popover>();
         Assert.True(popover.Instance.IsOpen);
+
+        cut.Find("button").Click();
+
+        Assert.False(popover.Instance.IsOpen);
     }
 
     [Fact]


### PR DESCRIPTION
- Toggle `Menu`, `Listbox` and `Popover` when clicking on their button instead of just opening (#7)