### PR TITLE
Fix inifinite looping bug of leaving transition with dialog rendered from outlet

### DIFF
--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
@@ -50,7 +50,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
             if (!_didRenderOnce) return;
 
             if (_transitioningTo == _show) return;
-            
+
             if (_show) EnterTransition();
             else LeaveTransition();
         }
@@ -165,7 +165,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
     protected override void LeaveTransition(Action? continueWith = null)
     {
         _transitioningTo = false;
-        
+
         WatchTransition(false, () =>
         {
             _show = false;

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
@@ -8,6 +8,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
     private readonly IList<ITransitionChild> _children = new List<ITransitionChild>();
     private readonly IList<IDialog> _dialogs = new List<IDialog>();
 
+    private bool _transitioningTo;
     private bool _didRenderOnce;
     private bool _showInitially;
     private Type? _asComponent;
@@ -48,6 +49,8 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
 
             if (!_didRenderOnce) return;
 
+            if (_transitioningTo == _show) return;
+            
             if (_show) EnterTransition();
             else LeaveTransition();
         }
@@ -153,7 +156,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
     /// <inheritdoc />
     protected override void EnterTransition(Action? continueWith = null)
     {
-        _show = true;
+        _transitioningTo = _show = true;
 
         WatchTransition(true, continueWith);
     }
@@ -161,6 +164,8 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
     /// <inheritdoc />
     protected override void LeaveTransition(Action? continueWith = null)
     {
+        _transitioningTo = false;
+        
         WatchTransition(false, () =>
         {
             _show = false;

--- a/tests/Ignis.Tests.Components.HeadlessUI/CustomModal.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/CustomModal.razor
@@ -1,0 +1,26 @@
+﻿@inherits IgnisRigidComponentBase
+
+<Transition AsComponent="typeof(Fragment)" Show="Open" Context="_">
+    <Dialog Context="dialog" IsOpenChanged="OpenChanged">
+        <TransitionChild AsComponent="typeof(Fragment)"
+                         Enter="duration-300"
+                         Leave="duration-200"
+                         Context="transition">
+            <DialogPanel>
+                @ChildContent
+            </DialogPanel>
+        </TransitionChild>
+    </Dialog>
+</Transition>
+
+@code
+{
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OpenChanged { get; set; }
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/CustomModalTest.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/CustomModalTest.razor
@@ -1,0 +1,15 @@
+﻿<DialogOutlet AsElement="div" id="dialog-outlet"/>
+
+<WrappedCustomModal @bind-Open="OpenBinding"/>
+<button id="open-button" @onclick="@(() => _isOpen = true)"></button>
+
+@code
+{
+    bool _isOpen;
+
+    bool OpenBinding
+    {
+        get => _isOpen;
+        set => _isOpen = value;
+    }
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -20,7 +20,7 @@
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var outletDiv = cut.Find($"#{outletId}");
         Assert.True(outletDiv.Contains(dialogDiv));
@@ -44,7 +44,7 @@
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var outletDiv = cut.Find($"#{outletId}");
         Assert.False(outletDiv.Contains(dialogDiv));
@@ -68,13 +68,13 @@
                                  <Dialog IsOpen id="@dialogId"></Dialog>
                              </Transition>
                          </div>);
-        
+
         var transitions = cut.FindAll($"#{transitionId}");
         Assert.Single(transitions);
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var transitionDiv = transitions.Single();
         var outletDiv = cut.Find($"#{outletId}");
@@ -100,13 +100,13 @@
                                  <Dialog IsOpen IgnoreOutlet id="@dialogId"></Dialog>
                              </Transition>
                          </div>);
-        
+
         var transitions = cut.FindAll($"#{transitionId}");
         Assert.Single(transitions);
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var transitionDiv = transitions.Single();
         var outletDiv = cut.Find($"#{outletId}");
@@ -149,7 +149,7 @@
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var transitionDiv = transitions.Single();
         var outletDiv = cut.Find($"#{outletId}");
@@ -196,7 +196,7 @@
 
         var dialogs = cut.FindAll($"#{dialogId}");
         Assert.Single(dialogs);
-        
+
         var dialogDiv = dialogs.Single();
         var transitionDiv = transitions.Single();
         var outletDiv = cut.Find($"#{outletId}");
@@ -206,7 +206,7 @@
         Assert.True(transitionDiv.Contains(dialogDiv));
         Assert.True(dialogDiv.Contains(transitionChildDiv));
         Assert.True(transitionChildDiv.Contains(dialogPanelDiv));
-        
+
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, false); });
 
         await Task.Delay(300);
@@ -216,7 +216,7 @@
 
         dialogs = cut.FindAll($"#{dialogId}");
         Assert.Empty(dialogs);
-        
+
         transitionDiv = transitions.Single();
         outletDiv = cut.Find($"#{outletId}");
         var transitionChildDivs = cut.FindAll($"#{transitionChildId}");
@@ -224,5 +224,40 @@
         Assert.True(outletDiv.Contains(transitionDiv));
         Assert.Empty(transitionChildDivs);
         Assert.Empty(dialogPanelDivs);
+    }
+
+    [Fact]
+    public async Task CustomModal_OpenCloseByButton()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        const string closeButtonId = "close-button";
+        const string openButtonId = "open-button";
+        const string outletId = "dialog-outlet";
+
+        var cut = Render<CustomModalTest>(@<CustomModalTest/>);
+        
+        var outlet = cut.Find($"#{outletId}");
+        Assert.Empty(outlet.Children);
+
+        var openButton = cut.Find($"#{openButtonId}");
+        openButton.Click();
+
+        await Task.Delay(400);
+        cut.Render();
+
+        var closeButton = cut.Find($"#{closeButtonId}");
+        Assert.True(outlet.Contains(closeButton));
+
+        closeButton.Click();
+
+        await Task.Delay(300);
+        cut.Render();
+
+        outlet = cut.Find($"#{outletId}");
+        Assert.Empty(outlet.Children);
     }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -160,4 +160,69 @@
         Assert.True(dialogDiv.Contains(transitionChildDiv));
         Assert.True(transitionChildDiv.Contains(dialogPanelDiv));
     }
+
+    [Fact]
+    public async Task OutletWithTransitionAndChildren_EnterLeaveWithDuration()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        const string dialogId = "dialog";
+        const string outletId = "dialog-outlet";
+        const string transitionId = "dialog-transition";
+        const string transitionChildId = "dialog-transition-child";
+        const string dialogPanelId = "dialog-panel";
+
+        var cut = Render(@<div>
+                             <DialogOutlet AsElement="div" id="@outletId"/>
+                             <Transition id="@transitionId" Enter="duration-300" Leave="duration-200" Context="transition">
+                                 <Dialog id="@dialogId" Context="dialog">
+                                     <TransitionChild id="@transitionChildId">
+                                         <DialogPanel id="@dialogPanelId"></DialogPanel>
+                                     </TransitionChild>
+                                 </Dialog>
+                             </Transition>
+                         </div>);
+
+        var transition = cut.FindComponent<Transition>();
+        transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
+
+        await Task.Delay(400);
+
+        var transitions = cut.FindAll($"#{transitionId}");
+        Assert.Single(transitions);
+
+        var dialogs = cut.FindAll($"#{dialogId}");
+        Assert.Single(dialogs);
+        
+        var dialogDiv = dialogs.Single();
+        var transitionDiv = transitions.Single();
+        var outletDiv = cut.Find($"#{outletId}");
+        var transitionChildDiv = cut.Find($"#{transitionChildId}");
+        var dialogPanelDiv = cut.Find($"#{dialogPanelId}");
+        Assert.True(outletDiv.Contains(transitionDiv));
+        Assert.True(transitionDiv.Contains(dialogDiv));
+        Assert.True(dialogDiv.Contains(transitionChildDiv));
+        Assert.True(transitionChildDiv.Contains(dialogPanelDiv));
+        
+        transition.SetParametersAndRender(p => { p.Add(x => x.Show, false); });
+
+        await Task.Delay(300);
+
+        transitions = cut.FindAll($"#{transitionId}");
+        Assert.Single(transitions);
+
+        dialogs = cut.FindAll($"#{dialogId}");
+        Assert.Empty(dialogs);
+        
+        transitionDiv = transitions.Single();
+        outletDiv = cut.Find($"#{outletId}");
+        var transitionChildDivs = cut.FindAll($"#{transitionChildId}");
+        var dialogPanelDivs = cut.FindAll($"#{dialogPanelId}");
+        Assert.True(outletDiv.Contains(transitionDiv));
+        Assert.Empty(transitionChildDivs);
+        Assert.Empty(dialogPanelDivs);
+    }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/WrappedCustomModal.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/WrappedCustomModal.razor
@@ -1,0 +1,19 @@
+﻿@inherits IgnisComponentBase
+
+<CustomModal Open="Open" OpenChanged="OpenChanged">
+    <button id="close-button" @onclick="@OnCloseAsync"></button>
+</CustomModal>
+
+@code
+{
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OpenChanged { get; set; }
+
+    private async Task OnCloseAsync()
+    {
+        await OpenChanged.InvokeAsync(false);
+    }
+}


### PR DESCRIPTION
This PR fixes a bug which causes a `Transition` with a `Dialog` rendered from the `DialogOutlet` to loop endlessly when leaving/closing.