### PR TITLE
Refactor internal frame tracking & time handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,10 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  NODE_ENV: development
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 18.x
       - run: npm i
-      - run: npx prettier --check .
+      #      - run: npx prettier --check .
       - run: dotnet test -c Release --settings .runsettings --filter FullyQualifiedName!~Ignis.Tests.E2E
       - uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  NODE_ENV: development
 
 jobs:
   Test:
@@ -17,7 +18,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 18.x
       - run: npm i
-      #      - run: npx prettier --check .
+      - run: npx prettier --check .
       - run: dotnet test -c Release --settings .runsettings --filter FullyQualifiedName!~Ignis.Tests.E2E
       - uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   Test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3

--- a/.github/workflows/nuget-cd.yml
+++ b/.github/workflows/nuget-cd.yml
@@ -19,7 +19,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ website/Ignis.Website.Server/wwwroot/_docs
 website/Ignis.Website.WebAssembly/wwwroot/_docs
 website/Ignis.Website/wwwroot/js/website.min.js
 website/Ignis.Website/wwwroot/css/tailwind.min.css
+tests/e2e/Ignis.Tests.E2E.Website/wwwroot/css/app.min.css

--- a/packages/Ignis.Components/FrameTracker.cs
+++ b/packages/Ignis.Components/FrameTracker.cs
@@ -20,7 +20,7 @@ internal class FrameTracker
     {
         _target = target ?? throw new ArgumentNullException(nameof(target));
         _action = action ?? throw new ArgumentNullException(nameof(action));
-        
+
         // If we're server-side, we can just execute the action on the next render, otherwise we need to wait for the second render. (WebAssembly)
         _frameToExecuteOn = _currentFrame + (_hostContext.IsServerSide ? 1 : 2);
     }
@@ -30,7 +30,7 @@ internal class FrameTracker
         if (_currentFrame >= _frameToExecuteOn)
         {
             _frameToExecuteOn = null;
-            
+
             _action?.Invoke();
 
             _action = null;
@@ -39,7 +39,7 @@ internal class FrameTracker
         {
             _target?.Update();
         }
-        
+
         ++_currentFrame;
     }
 }

--- a/packages/Ignis.Components/FrameTracker.cs
+++ b/packages/Ignis.Components/FrameTracker.cs
@@ -2,8 +2,6 @@
 
 internal class FrameTracker
 {
-    private readonly IHostContext _hostContext;
-
     private long _currentFrame;
     private long? _frameToExecuteOn;
     private IgnisComponentBase? _target;
@@ -11,18 +9,12 @@ internal class FrameTracker
 
     public bool IsPending => _action != null;
 
-    public FrameTracker(IHostContext hostContext)
-    {
-        _hostContext = hostContext ?? throw new ArgumentNullException(nameof(hostContext));
-    }
-
     public void ExecuteOnNextFrame(IgnisComponentBase target, Action action)
     {
         _target = target ?? throw new ArgumentNullException(nameof(target));
         _action = action ?? throw new ArgumentNullException(nameof(action));
 
-        // If we're server-side, we can just execute the action on the next render, otherwise we need to wait for the second render. (WebAssembly)
-        _frameToExecuteOn = _currentFrame + (_hostContext.IsServerSide ? 1 : 2);
+        _frameToExecuteOn = _currentFrame + 1;
     }
 
     public void OnAfterRender()

--- a/packages/Ignis.Components/ITimer.cs
+++ b/packages/Ignis.Components/ITimer.cs
@@ -1,0 +1,7 @@
+﻿namespace Ignis.Components;
+
+//TODO switch to System.Threading.ITimer when it's available
+// https://learn.microsoft.com/en-us/dotnet/api/system.threading.itimer?view=net-8.0
+internal interface ITimer : IDisposable
+{
+}

--- a/packages/Ignis.Components/Ignis.Components.csproj
+++ b/packages/Ignis.Components/Ignis.Components.csproj
@@ -23,6 +23,7 @@
     <InternalsVisibleTo Include="Ignis.Components.HeadlessUI"/>
     <InternalsVisibleTo Include="Ignis.Components.Reactivity"/>
     <InternalsVisibleTo Include="Ignis.Components.Web"/>
+    <InternalsVisibleTo Include="Ignis.Tests.Common"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/packages/Ignis.Components/IgnisComponentExtensions.cs
+++ b/packages/Ignis.Components/IgnisComponentExtensions.cs
@@ -15,7 +15,7 @@ public static class IgnisComponentExtensions
 
         serviceCollection.TryAddScoped<IContentRegistry, ContentRegistry>();
 
-        serviceCollection.TryAddSingleton<TimeProvider, IgnisTimeProvider>();
+        serviceCollection.TryAddSingleton<TimeProvider, TimeProviderImplementation>();
 
         return serviceCollection;
     }

--- a/packages/Ignis.Components/IgnisComponentExtensions.cs
+++ b/packages/Ignis.Components/IgnisComponentExtensions.cs
@@ -14,7 +14,7 @@ public static class IgnisComponentExtensions
         serviceCollection.AddTransient<FrameTracker>();
 
         serviceCollection.TryAddScoped<IContentRegistry, ContentRegistry>();
-        
+
         serviceCollection.TryAddSingleton<TimeProvider, IgnisTimeProvider>();
 
         return serviceCollection;

--- a/packages/Ignis.Components/IgnisComponentExtensions.cs
+++ b/packages/Ignis.Components/IgnisComponentExtensions.cs
@@ -14,6 +14,8 @@ public static class IgnisComponentExtensions
         serviceCollection.AddTransient<FrameTracker>();
 
         serviceCollection.TryAddScoped<IContentRegistry, ContentRegistry>();
+        
+        serviceCollection.TryAddSingleton<TimeProvider, IgnisTimeProvider>();
 
         return serviceCollection;
     }

--- a/packages/Ignis.Components/IgnisTimeProvider.cs
+++ b/packages/Ignis.Components/IgnisTimeProvider.cs
@@ -1,5 +1,0 @@
-﻿namespace Ignis.Components;
-
-internal class IgnisTimeProvider : TimeProvider
-{
-}

--- a/packages/Ignis.Components/IgnisTimeProvider.cs
+++ b/packages/Ignis.Components/IgnisTimeProvider.cs
@@ -1,0 +1,5 @@
+﻿namespace Ignis.Components;
+
+internal class IgnisTimeProvider : TimeProvider
+{
+}

--- a/packages/Ignis.Components/TimeProvider.cs
+++ b/packages/Ignis.Components/TimeProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace Ignis.Components;
+
+//TODO switch to System.TimeProvider when it's available
+// https://learn.microsoft.com/en-us/dotnet/api/system.timeprovider?view=net-8.0
+internal abstract class TimeProvider
+{
+    public virtual Timer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        return new Timer(callback, state, dueTime, period);
+    }
+}

--- a/packages/Ignis.Components/TimeProvider.cs
+++ b/packages/Ignis.Components/TimeProvider.cs
@@ -4,8 +4,8 @@
 // https://learn.microsoft.com/en-us/dotnet/api/system.timeprovider?view=net-8.0
 internal abstract class TimeProvider
 {
-    public virtual Timer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    public virtual ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
-        return new Timer(callback, state, dueTime, period);
+        return new TimerImplementation(callback, state, dueTime, period);
     }
 }

--- a/packages/Ignis.Components/TimeProviderImplementation.cs
+++ b/packages/Ignis.Components/TimeProviderImplementation.cs
@@ -1,0 +1,5 @@
+﻿namespace Ignis.Components;
+
+internal class TimeProviderImplementation : TimeProvider
+{
+}

--- a/packages/Ignis.Components/TimerImplementation.cs
+++ b/packages/Ignis.Components/TimerImplementation.cs
@@ -1,0 +1,16 @@
+﻿namespace Ignis.Components;
+
+internal class TimerImplementation : ITimer
+{
+    private readonly Timer _timer;
+
+    public TimerImplementation(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        _timer = new Timer(callback, state, dueTime, period);
+    }
+
+    public void Dispose()
+    {
+        _timer.Dispose();
+    }
+}

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Dialog.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Dialog.cs
@@ -226,7 +226,7 @@ public sealed class Dialog : IgnisContentProviderComponentBase, IDialog, IHandle
     /// <inheritdoc />
     public void CloseFromTransition(Action? continueWith = null)
     {
-        CloseCore(continueWith, true);
+        CloseCore(continueWith, async: true);
     }
 
     /// <inheritdoc />

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Dialog.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Dialog.cs
@@ -179,7 +179,7 @@ public sealed class Dialog : IgnisContentProviderComponentBase, IDialog, IHandle
 
         var __ = IsOpenChanged.InvokeAsync(_isOpen = true);
 
-        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(continueWith, Update);
+        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(this, continueWith);
 
         Update();
     }
@@ -206,7 +206,7 @@ public sealed class Dialog : IgnisContentProviderComponentBase, IDialog, IHandle
     {
         var __ = IsOpenChanged.InvokeAsync(_isOpen = false);
 
-        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(continueWith, Update);
+        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(this, continueWith);
 
         Update(async);
     }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/OpenCloseWithTransitionComponentBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/OpenCloseWithTransitionComponentBase.cs
@@ -38,8 +38,8 @@ public abstract class OpenCloseWithTransitionComponentBase : FocusComponentBase,
         _ = IsOpenChanged.InvokeAsync(_isOpen = true);
 
         if (_transition != null)
-            FrameTracker.ExecuteOnNextFrame(() => _transition.Show(() => OnAfterOpen(continueWith)), Update);
-        else if (continueWith != null) FrameTracker.ExecuteOnNextFrame(() => OnAfterOpen(continueWith), Update);
+            FrameTracker.ExecuteOnNextFrame(this, () => _transition.Show(() => OnAfterOpen(continueWith)));
+        else if (continueWith != null) FrameTracker.ExecuteOnNextFrame(this, () => OnAfterOpen(continueWith));
 
         Update();
     }
@@ -73,7 +73,7 @@ public abstract class OpenCloseWithTransitionComponentBase : FocusComponentBase,
     {
         _ = IsOpenChanged.InvokeAsync(_isOpen = false);
 
-        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(continueWith, Update);
+        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(this, continueWith);
 
         Update(async);
     }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
@@ -58,7 +58,6 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
 
     [Parameter] public bool Appear { get; set; }
 
-    /// <inheritdoc />
     [CascadingParameter] public IContentHost? Outlet { get; set; }
 
     [CascadingParameter] public IMenu? Menu { get; set; }
@@ -221,7 +220,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
         var startedTransitions = new List<ITransitionChild>();
         var finishedTransitions = 0;
 
-        if (isEnter) base.EnterTransition(() => AggregateDialogs(true, ContinueWith));
+        if (isEnter) base.EnterTransition(() => AggregateDialogs(open: true, ContinueWith));
         else ContinueWith();
         return;
 
@@ -243,7 +242,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
             if (finishedTransitions == startedTransitions.Count + 1)
             {
                 if (isEnter) continueWith?.Invoke();
-                else AggregateDialogs(false, () => base.LeaveTransition(continueWith));
+                else AggregateDialogs(open: false, () => base.LeaveTransition(continueWith));
             }
         }
     }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/Transition.cs
@@ -173,7 +173,7 @@ public sealed class Transition : TransitionBase, ITransition, IDisposable
     {
         _transitioningTo = false;
 
-        WatchTransition(false, () =>
+        WatchTransition(isEnter: false, () =>
         {
             _show = false;
 

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
@@ -120,7 +120,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         _state = state;
 
-        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(continueWith, Update);
+        if (continueWith != null) FrameTracker.ExecuteOnNextFrame(this, continueWith);
 
         Update(async: true);
     }

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
@@ -122,7 +122,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         if (continueWith != null) FrameTracker.ExecuteOnNextFrame(continueWith, Update);
 
-        Update(true);
+        Update(async: true);
     }
 
     /// <inheritdoc />

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
@@ -79,7 +79,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         UpdateState(TransitionState.Entering, () =>
         {
-            Timer timer = null!;
+            ITimer timer = null!;
             var (graceDuration, transitionDuration) = ParseDuration(Enter);
             timer = TimeProvider.CreateTimer(_ =>
             {
@@ -106,7 +106,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         UpdateState(TransitionState.Leaving, () =>
         {
-            Timer timer = null!;
+            ITimer timer = null!;
             var (graceDuration, transitionDuration) = ParseDuration(Leave);
             timer = TimeProvider.CreateTimer(_ =>
             {

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
@@ -68,7 +68,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
     }
 
     [Inject] internal FrameTracker FrameTracker { get; set; } = null!;
-    
+
     [Inject] internal TimeProvider TimeProvider { get; set; } = null!;
 
     protected virtual void EnterTransition(Action? continueWith = null)
@@ -79,13 +79,18 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         UpdateState(TransitionState.Entering, () =>
         {
+            Timer timer = null!;
             var (graceDuration, transitionDuration) = ParseDuration(Enter);
-            using var timer = TimeProvider.CreateTimer(_ =>
+            timer = TimeProvider.CreateTimer(_ =>
             {
+                // ReSharper disable once AccessToModifiedClosure
+                timer.Dispose();
                 UpdateState(TransitionState.Entered, () =>
                 {
-                    using var timer = TimeProvider.CreateTimer(_ =>
+                    timer = TimeProvider.CreateTimer(_ =>
                     {
+                        // ReSharper disable once AccessToModifiedClosure
+                        timer.Dispose();
                         UpdateState(TransitionState.CanLeave, continueWith);
                     }, state: null, transitionDuration, Timeout.InfiniteTimeSpan);
                 });
@@ -101,13 +106,19 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
 
         UpdateState(TransitionState.Leaving, () =>
         {
+            Timer timer = null!;
             var (graceDuration, transitionDuration) = ParseDuration(Leave);
-            using var timer = TimeProvider.CreateTimer(_ =>
+            timer = TimeProvider.CreateTimer(_ =>
             {
+                // ReSharper disable once AccessToModifiedClosure
+                timer.Dispose();
                 UpdateState(TransitionState.Left, () =>
                 {
-                    using var timer = TimeProvider.CreateTimer(_ =>
+                    timer = TimeProvider.CreateTimer(_ =>
                     {
+                        // ReSharper disable once AccessToModifiedClosure
+                        timer.Dispose();
+                        
                         RenderContent = false;
 
                         UpdateState(TransitionState.CanEnter, continueWith);

--- a/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
+++ b/packages/Tailwind/Ignis.Components.HeadlessUI/TransitionBase.cs
@@ -118,7 +118,7 @@ public abstract class TransitionBase : IgnisComponentBase, ICssClass, IHandleAft
                     {
                         // ReSharper disable once AccessToModifiedClosure
                         timer.Dispose();
-                        
+
                         RenderContent = false;
 
                         UpdateState(TransitionState.CanEnter, continueWith);

--- a/tests/Ignis.Tests.Common/IgnisTestExtensions.cs
+++ b/tests/Ignis.Tests.Common/IgnisTestExtensions.cs
@@ -12,7 +12,7 @@ public static class IgnisTestExtensions
         serviceCollection.AddIgnis();
         serviceCollection.AddSingleton<IHostContext, TestHostContext>();
         serviceCollection.AddSingleton<TimeProvider, TestTimeProvider>();
-        
+
         return serviceCollection;
     }
 }

--- a/tests/Ignis.Tests.Common/IgnisTestExtensions.cs
+++ b/tests/Ignis.Tests.Common/IgnisTestExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Ignis.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ignis.Tests.Common;
+
+public static class IgnisTestExtensions
+{
+    public static IServiceCollection AddIgnisTestServices(this IServiceCollection serviceCollection)
+    {
+        if (serviceCollection == null) throw new ArgumentNullException(nameof(serviceCollection));
+
+        serviceCollection.AddIgnis();
+        serviceCollection.AddSingleton<IHostContext, TestHostContext>();
+        serviceCollection.AddSingleton<TimeProvider, TestTimeProvider>();
+        
+        return serviceCollection;
+    }
+}

--- a/tests/Ignis.Tests.Common/TestHostContext.cs
+++ b/tests/Ignis.Tests.Common/TestHostContext.cs
@@ -2,7 +2,7 @@
 
 namespace Ignis.Tests.Common;
 
-public class TestHostContext : IHostContext
+internal class TestHostContext : IHostContext
 {
     public bool IsPrerendering => false;
 

--- a/tests/Ignis.Tests.Common/TestTimeProvider.cs
+++ b/tests/Ignis.Tests.Common/TestTimeProvider.cs
@@ -6,7 +6,6 @@ internal class TestTimeProvider : TimeProvider
 {
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
-        callback(state);
-        return new TestTimer();
+        return new TestTimer(callback);
     }
 }

--- a/tests/Ignis.Tests.Common/TestTimeProvider.cs
+++ b/tests/Ignis.Tests.Common/TestTimeProvider.cs
@@ -6,6 +6,6 @@ internal class TestTimeProvider : TimeProvider
 {
     public override Timer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
-        return base.CreateTimer(callback, state, TimeSpan.Zero, TimeSpan.Zero);
+        return base.CreateTimer(callback, state, TimeSpan.Zero, Timeout.InfiniteTimeSpan);
     }
 }

--- a/tests/Ignis.Tests.Common/TestTimeProvider.cs
+++ b/tests/Ignis.Tests.Common/TestTimeProvider.cs
@@ -4,8 +4,9 @@ namespace Ignis.Tests.Common;
 
 internal class TestTimeProvider : TimeProvider
 {
-    public override Timer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
-        return base.CreateTimer(callback, state, TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+        callback(state);
+        return new TestTimer();
     }
 }

--- a/tests/Ignis.Tests.Common/TestTimeProvider.cs
+++ b/tests/Ignis.Tests.Common/TestTimeProvider.cs
@@ -1,0 +1,11 @@
+﻿using Ignis.Components;
+
+namespace Ignis.Tests.Common;
+
+internal class TestTimeProvider : TimeProvider
+{
+    public override Timer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        return base.CreateTimer(callback, state, TimeSpan.Zero, TimeSpan.Zero);
+    }
+}

--- a/tests/Ignis.Tests.Common/TestTimer.cs
+++ b/tests/Ignis.Tests.Common/TestTimer.cs
@@ -7,7 +7,7 @@ internal class TestTimer : ITimer
     public TestTimer()
     {
     }
-    
+
     public void Dispose()
     {
     }

--- a/tests/Ignis.Tests.Common/TestTimer.cs
+++ b/tests/Ignis.Tests.Common/TestTimer.cs
@@ -1,0 +1,14 @@
+﻿using Ignis.Components;
+
+namespace Ignis.Tests.Common;
+
+internal class TestTimer : ITimer
+{
+    public TestTimer()
+    {
+    }
+    
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Ignis.Tests.Common/TestTimer.cs
+++ b/tests/Ignis.Tests.Common/TestTimer.cs
@@ -2,13 +2,29 @@
 
 namespace Ignis.Tests.Common;
 
-internal class TestTimer : ITimer
+public sealed class TestTimer : ITimer
 {
-    public TestTimer()
+    private static readonly List<TestTimer> Timers = new();
+
+    private readonly TimerCallback _callback;
+
+    public TestTimer(TimerCallback callback)
     {
+        _callback = callback;
+
+        Timers.Add(this);
+    }
+
+    public static void Trigger(object? state)
+    {
+        foreach (var timer in Timers.ToArray())
+        {
+            timer._callback(state);
+        }
     }
 
     public void Dispose()
     {
+        Timers.Remove(this);
     }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -137,7 +137,10 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
-        var transitions = cut.WaitForElements($"#{transitionId}");
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+
+        var transitions = cut.FindAll($"#{transitionId}");
         Assert.Single(transitions);
 
         var dialogs = cut.WaitForElements($"#{dialogId}");
@@ -181,6 +184,9 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+
         var transitions = cut.WaitForElements($"#{transitionId}");
         Assert.Single(transitions);
 
@@ -198,6 +204,9 @@
         Assert.True(transitionChildDiv.Contains(dialogPanelDiv));
 
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, false); });
+
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
 
         cut.WaitForState(() => cut.FindAll($"#{dialogId}").Count == 0);
         
@@ -232,10 +241,16 @@
         var openButton = cut.Find($"#{openButtonId}");
         openButton.Click();
 
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        
         var closeButton = cut.WaitForElement($"#{closeButtonId}");
         Assert.True(outlet.Contains(closeButton));
         
         closeButton.Click();
+
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
         
         cut.WaitForState(() => cut.FindAll($"#{closeButtonId}").Count == 0);
         

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -246,14 +246,12 @@
         var openButton = cut.Find($"#{openButtonId}");
         openButton.Click();
 
-        await Task.Delay(400);
-
-        var closeButton = cut.Find($"#{closeButtonId}");
+        var closeButton = cut.WaitForElement($"#{closeButtonId}");
         Assert.True(outlet.Contains(closeButton));
 
         closeButton.Click();
 
-        await Task.Delay(300);
+        await Task.Delay(400);
 
         outlet = cut.Find($"#{outletId}");
         Assert.Empty(outlet.Children);

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -238,7 +238,7 @@
         const string openButtonId = "open-button";
         const string outletId = "dialog-outlet";
 
-        var cut = Render<CustomDialogTest>(@<CustomDialogTest/>);
+        var cut = Render(@<CustomDialogTest/>);
         
         var outlet = cut.Find($"#{outletId}");
         Assert.Empty(outlet.Children);
@@ -247,7 +247,6 @@
         openButton.Click();
 
         await Task.Delay(400);
-        cut.Render();
 
         var closeButton = cut.Find($"#{closeButtonId}");
         Assert.True(outlet.Contains(closeButton));
@@ -255,7 +254,6 @@
         closeButton.Click();
 
         await Task.Delay(300);
-        cut.Render();
 
         outlet = cut.Find($"#{outletId}");
         Assert.Empty(outlet.Children);

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -137,12 +137,10 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
-        await Task.Delay(100);
-
-        var transitions = cut.FindAll($"#{transitionId}");
+        var transitions = cut.WaitForElements($"#{transitionId}");
         Assert.Single(transitions);
 
-        var dialogs = cut.FindAll($"#{dialogId}");
+        var dialogs = cut.WaitForElements($"#{dialogId}");
         Assert.Single(dialogs);
 
         var dialogDiv = dialogs.Single();
@@ -183,9 +181,7 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
-        await Task.Delay(400);
-
-        var transitions = cut.FindAll($"#{transitionId}");
+        var transitions = cut.WaitForElements($"#{transitionId}");
         Assert.Single(transitions);
 
         var dialogs = cut.FindAll($"#{dialogId}");
@@ -203,14 +199,11 @@
 
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, false); });
 
-        await Task.Delay(300);
-
+        cut.WaitForState(() => cut.FindAll($"#{dialogId}").Count == 0);
+        
         transitions = cut.FindAll($"#{transitionId}");
         Assert.Single(transitions);
-
-        dialogs = cut.FindAll($"#{dialogId}");
-        Assert.Empty(dialogs);
-
+        
         transitionDiv = transitions.Single();
         outletDiv = cut.Find($"#{outletId}");
         var transitionChildDivs = cut.FindAll($"#{transitionChildId}");

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -137,6 +137,10 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
+        // Transition
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        // TransitionChild
         TestTimer.Trigger(null);
         TestTimer.Trigger(null);
 
@@ -184,6 +188,10 @@
         var transition = cut.FindComponent<Transition>();
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, true); });
 
+        // Transition
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        // TransitionChild
         TestTimer.Trigger(null);
         TestTimer.Trigger(null);
 
@@ -205,6 +213,10 @@
 
         transition.SetParametersAndRender(p => { p.Add(x => x.Show, false); });
 
+        // Transition
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        // TransitionChild
         TestTimer.Trigger(null);
         TestTimer.Trigger(null);
 
@@ -241,6 +253,10 @@
         var openButton = cut.Find($"#{openButtonId}");
         openButton.Click();
 
+        // Transition
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        // TransitionChild
         TestTimer.Trigger(null);
         TestTimer.Trigger(null);
         
@@ -249,6 +265,10 @@
         
         closeButton.Click();
 
+        // Transition
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+        // TransitionChild
         TestTimer.Trigger(null);
         TestTimer.Trigger(null);
         

--- a/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/DialogTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Outlet()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -29,8 +28,7 @@
     [Fact]
     public void IgnoreOutlet()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -53,8 +51,7 @@
     [Fact]
     public void OutletWithTransition()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -85,8 +82,7 @@
     [Fact]
     public void IgnoreOutletWithTransition()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -117,8 +113,7 @@
     [Fact]
     public async Task OutletWithTransitionAndChildren()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -164,8 +159,7 @@
     [Fact]
     public async Task OutletWithTransitionAndChildren_EnterLeaveWithDuration()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -229,8 +223,7 @@
     [Fact]
     public async Task CustomModal_OpenCloseByButton()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -248,11 +241,11 @@
 
         var closeButton = cut.WaitForElement($"#{closeButtonId}");
         Assert.True(outlet.Contains(closeButton));
-
+        
         closeButton.Click();
-
-        await Task.Delay(400);
-
+        
+        cut.WaitForState(() => cut.FindAll($"#{closeButtonId}").Count == 0);
+        
         outlet = cut.Find($"#{outletId}");
         Assert.Empty(outlet.Children);
     }

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialog.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialog.razor
@@ -1,0 +1,40 @@
+﻿@inherits IgnisRigidComponentBase
+
+<CustomDialog Open="Open" OpenChanged="OpenChanged">
+    <Listbox @bind-Value="_selectedType">
+        <ListboxButton Id="listbox-button">
+        </ListboxButton>
+        <Transition AsComponent="typeof(Fragment)"
+                    Leave="duration-100"
+                    Context="transition">
+            <ListboxOptions @attributes="transition.Attributes">
+                @foreach (var option in _options)
+                {
+                    <ListboxOption @key="option.Name" 
+                                   Value="option"
+                                   Context="_">
+                        @option.Name
+                    </ListboxOption>
+                }
+            </ListboxOptions>
+        </Transition>
+    </Listbox>
+</CustomDialog>
+
+@code
+{
+    private readonly Type[] _options =
+    {
+        typeof(string),
+        typeof(int),
+        typeof(bool)
+    };
+
+    private Type? _selectedType;
+
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OpenChanged { get; set; }
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialog.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialog.razor
@@ -11,7 +11,7 @@
                 @foreach (var option in _options)
                 {
                     <ListboxOption @key="option.Name" 
-                                   Value="option"
+                                   Value="option" id="@option.Name"
                                    Context="_">
                         @option.Name
                     </ListboxOption>

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialogTest.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxInDialogTest.razor
@@ -1,0 +1,7 @@
+﻿<ListboxInDialog @bind-Open="_isOpen"></ListboxInDialog>
+<button id="open-button" @onclick="@(() => _isOpen = true)"></button>
+
+@code
+{
+    bool _isOpen;
+}

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -58,6 +58,9 @@
         var openButton = cut.Find($"#{openButtonId}");
         openButton.Click();
 
+        TestTimer.Trigger(null);
+        TestTimer.Trigger(null);
+
         var listboxButton = cut.WaitForElement($"#{listboxButtonId}");
         listboxButton.Click();
 

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -51,27 +51,26 @@
         Services.AddSingleton<IHostContext, TestHostContext>();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
-        
+
         const string openButtonId = "open-button";
         const string listboxButtonId = "listbox-button";
         const string intOptionId = nameof(Int32);
 
         var cut = Render(@<ListboxInDialogTest></ListboxInDialogTest>);
-        
+
         var openButton = cut.Find($"#{openButtonId}");
         openButton.Click();
 
-        await Task.Delay(400);
-
-        var listboxButton = cut.Find($"#{listboxButtonId}");
+        var listboxButton = cut.WaitForElement($"#{listboxButtonId}");
         listboxButton.Click();
 
         var intOption = cut.Find($"#{intOptionId}");
         intOption.Click();
 
-        await Task.Delay(200);
-        
-        var listbox = cut.FindComponent<Listbox<Type>>();
-        Assert.Equal(typeof(int), listbox.Instance.Value);
+        cut.WaitForAssertion(() =>
+        {
+            var listbox = cut.FindComponent<Listbox<Type>>();
+            Assert.Equal(typeof(int), listbox.Instance.Value);
+        });
     }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Button_OnClick()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -28,8 +27,7 @@
     [Fact]
     public void Button_OnClick_PreventDefault()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -47,8 +45,7 @@
     [Fact]
     public async Task ListboxInDialog()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -64,7 +61,7 @@
         var listboxButton = cut.WaitForElement($"#{listboxButtonId}");
         listboxButton.Click();
 
-        var intOption = cut.Find($"#{intOptionId}");
+        var intOption = cut.WaitForElement($"#{intOptionId}");
         intOption.Click();
 
         cut.WaitForAssertion(() =>

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -43,4 +43,26 @@
         var listbox = cut.FindComponent<Listbox<object>>();
         Assert.False(listbox.Instance.IsOpen);
     }
+
+    [Fact]
+    public async Task ListboxInDialog()
+    {
+        Services.AddIgnis();
+        Services.AddSingleton<IHostContext, TestHostContext>();
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        
+        const string openButtonId = "open-button";
+        const string listboxButtonId = "listbox-button";
+
+        var cut = Render(@<ListboxInDialogTest></ListboxInDialogTest>);
+        
+        var openButton = cut.Find($"#{openButtonId}");
+        openButton.Click();
+
+        await Task.Delay(400);
+
+        var listboxButton = cut.Find($"#{listboxButtonId}");
+        listboxButton.Click();
+    }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/ListboxTests.razor
@@ -54,6 +54,7 @@
         
         const string openButtonId = "open-button";
         const string listboxButtonId = "listbox-button";
+        const string intOptionId = nameof(Int32);
 
         var cut = Render(@<ListboxInDialogTest></ListboxInDialogTest>);
         
@@ -64,5 +65,13 @@
 
         var listboxButton = cut.Find($"#{listboxButtonId}");
         listboxButton.Click();
+
+        var intOption = cut.Find($"#{intOptionId}");
+        intOption.Click();
+
+        await Task.Delay(200);
+        
+        var listbox = cut.FindComponent<Listbox<Type>>();
+        Assert.Equal(typeof(int), listbox.Instance.Value);
     }
 }

--- a/tests/Ignis.Tests.Components.HeadlessUI/MenuTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/MenuTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Button_OnClick()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -28,8 +27,7 @@
     [Fact]
     public void Button_OnClick_PreventDefault()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 

--- a/tests/Ignis.Tests.Components.HeadlessUI/PopoverTests.razor
+++ b/tests/Ignis.Tests.Components.HeadlessUI/PopoverTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Button_OnClick()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -28,8 +27,7 @@
     [Fact]
     public void Button_OnClick_PreventDefault()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         JSInterop.Mode = JSRuntimeMode.Loose;
 

--- a/tests/Ignis.Tests.Components.Reactivity/ReactiveSectionTests.razor
+++ b/tests/Ignis.Tests.Components.Reactivity/ReactiveSectionTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Test()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
         
         var cut = RenderComponent<AlternatingCounter>();
 

--- a/tests/Ignis.Tests.Components.Reactivity/ReactiveValueTests.razor
+++ b/tests/Ignis.Tests.Components.Reactivity/ReactiveValueTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void SilentCounter()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         var cut = RenderComponent<SilentCounter>();
         Assert.Equal(1, cut.RenderCount);
@@ -25,8 +24,7 @@
     [Fact]
     public void ReactiveCounter()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         var cut = RenderComponent<ReactiveCounter>();
         Assert.Equal(1, cut.RenderCount);

--- a/tests/Ignis.Tests.Components/IgnisAsyncComponentBaseTests.razor
+++ b/tests/Ignis.Tests.Components/IgnisAsyncComponentBaseTests.razor
@@ -5,8 +5,7 @@
     [Fact]
     public void Cycle()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         const string echo1 = "Hello World!";
         const string echo2 = "Lorem Ipsum dolor sit amet.";
@@ -27,8 +26,7 @@
     [Fact]
     public void AlreadyDisposed()
     {
-        Services.AddIgnis();
-        Services.AddSingleton<IHostContext, TestHostContext>();
+        Services.AddIgnisTestServices();
 
         const string echo1 = "Hello World!";
         const string echo2 = "Lorem Ipsum dolor sit amet.";


### PR DESCRIPTION
This PR refactors the internal `FrameTracker` class to have consistent frame tracking available for all components.
This PR also introduces a small implementation of the future .NET 8 `TimeProvider` class and the `ITimer` interface to not rely on `Task.Delay` anymore.

This fixes a couple of problems when combining multiple `Transition`, `TransitionChild` and other opening/closing components (e.g. `Listbox` or `Dialog`).