### PR TITLE
Allow prerendering components

### DIFF
--- a/docs/components/ComponentLifecycle.md
+++ b/docs/components/ComponentLifecycle.md
@@ -53,7 +53,19 @@ public class MyComponent : IgnisComponentBase, IHandleAfterRender, IHandleEvent
 
 ## `ServerPrerendered` rendering mode
 
-Also contrary to Razor components, Ignis component's lifecycle methods are not called twice when the rendering mode is
-set to `ServerPrerendered`.
+Contrary to Razor components, Ignis component's lifecycle methods are not called twice when the rendering mode is set
+to `ServerPrerendered`.
 
-If you still want to have the same behaviour as Razor components, you can implement the `IHandleAfterRender` interface.
+If you still want to prerender your Ignis components, you can use the `PrerenderAttribute` to enable prerendering:
+
+```csharp
+@attribute [Prerender]
+@inherits IgnisComponentBase
+
+<div>
+    This content will be prerendered.
+</div>
+```
+
+The prerender cycle will happen without calling the `OnInitialized` and `OnUpdate` methods. This can be useful if you
+want to render loading states, placeholders or search engine relevant content.

--- a/packages/Ignis.Components/IgnisComponentBase.cs
+++ b/packages/Ignis.Components/IgnisComponentBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Ignis.Components;
@@ -37,7 +38,17 @@ public abstract class IgnisComponentBase : IComponent
 
     public async Task SetParametersAsync(ParameterView parameters)
     {
-        if (HostContext.IsPrerendering) return;
+        if (HostContext.IsPrerendering)
+        {
+            var prerenderAttribute = GetType().GetCustomAttribute<PrerenderAttribute>();
+            if (prerenderAttribute == null) return;
+
+            parameters.SetParameterProperties(this);
+                
+            UpdateCore(async: false);
+
+            return;
+        }
 
         parameters.SetParameterProperties(this);
 

--- a/packages/Ignis.Components/IgnisComponentBase.cs
+++ b/packages/Ignis.Components/IgnisComponentBase.cs
@@ -44,7 +44,7 @@ public abstract class IgnisComponentBase : IComponent
             if (prerenderAttribute == null) return;
 
             parameters.SetParameterProperties(this);
-                
+
             UpdateCore(async: false);
 
             return;

--- a/packages/Ignis.Components/PrerenderAttribute.cs
+++ b/packages/Ignis.Components/PrerenderAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace Ignis.Components;
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class PrerenderAttribute : Attribute
+{
+}

--- a/tests/Ignis.Tests.Components/PrerenderComponentTests.razor
+++ b/tests/Ignis.Tests.Components/PrerenderComponentTests.razor
@@ -1,0 +1,59 @@
+﻿@using Ignis.Components.Extensions
+@using Microsoft.AspNetCore.Components.Rendering
+@inherits TestContext
+
+@code
+{
+    [Fact]
+    public void Cycle()
+    {
+        Services.AddIgnis();
+        
+        var context = new PrerenderHostContext();
+        Services.AddSingleton<IHostContext>(context);
+        
+        context.IsPrerenderingValue = true;
+        
+        var cut = RenderComponent<PrerenderComponent>();
+        
+        var result = cut.Markup;
+        Assert.Equal("OnPrerender", result);
+        
+        context.IsPrerenderingValue = false;
+        
+        cut.Render();
+        
+        result = cut.Markup;
+        
+        Assert.Equal("OnInitialized", result);
+    }
+
+    [Prerender]
+    class PrerenderComponent : IgnisComponentBase
+    {
+        private string _message = "OnPrerender";
+
+        protected override void OnInitialized()
+        {
+            _message = "OnInitialized";
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.AddContent(0, _message);
+        }
+    }
+
+    class PrerenderHostContext : HostContextBase
+    {
+        public bool IsPrerenderingValue { get; set; }
+
+        public override bool IsPrerendering => IsPrerenderingValue;
+
+        public override bool IsServerSide => false;
+
+        public PrerenderHostContext() : base(Array.Empty<IComponentExtension>())
+        {
+        }
+    }
+}


### PR DESCRIPTION
Introduce the `PrerenderAttribute` to allow prerendering components before the component lifecycle happens.